### PR TITLE
Use explicit count modifiers

### DIFF
--- a/Syntaxes/IDL.tmLanguage
+++ b/Syntaxes/IDL.tmLanguage
@@ -269,7 +269,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-zA-Z0-9]+)</string>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-zA-Z0-9]+)</string>
 					<key>name</key>
 					<string>constant.character.escape.idl</string>
 				</dict>


### PR DESCRIPTION
The construction `{,n}` in regular expressions is only supported by Oniguruma (which is used by TextMate). This TextMate bundle is used to highlight IDL code on github.com. However, github.com is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes.

This pull request fixes that by using explicit count modifiers.