### PR TITLE
Remove invalid isDisabled key

### DIFF
--- a/Syntaxes/IDL.tmLanguage
+++ b/Syntaxes/IDL.tmLanguage
@@ -8,8 +8,6 @@
 	</array>
 	<key>firstLineMatch</key>
 	<string>-[*]-( Mode:)? IDL -[*]-</string>
-	<key>isDisabled</key>
-	<false/>
 	<key>keyEquivalent</key>
 	<string>^~@i</string>
 	<key>name</key>


### PR DESCRIPTION
Is the `isDisabled` serving any purpose? It's detected as invalid on GitHub.com and throwing errors (see github/linguist#3924 for further details).